### PR TITLE
Update linter.py

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,12 +11,12 @@ class Perl(Linter):
     multiline = False
     syntax = ('Perl')
     regex = (
-        r'(?P<stdin>.*)line (?P<line>\d+),(?P<message>.*)'
+        r'(?P<message>.*?) at .*? line (?P<line>\d+)'
     )
     base_cmd = (
     '-c'
     )
-    tempfile_suffix = 'pl'
+    tempfile_suffix = '.pl'
 
 
     def split_match(self, match):


### PR DESCRIPTION
This change will support the following error messages:

* `syntax error at test.pl line 4, near "asdasdasd
	print"
test.pl had compilation errors.`

This is caused by a missing `;` in the code

* `Bareword "asdasdasd" not allowed while "strict subs" in use at bin/test.pl line 31.
bin/test.pl had compilation errors.`

caused by using strict mode;


Also has the side efect of simplification of the regexp